### PR TITLE
Apply autocorrections from 'brew style --fix'

### DIFF
--- a/carton.rb
+++ b/carton.rb
@@ -1,11 +1,10 @@
+# typed: false
+# frozen_string_literal: true
+
 class Carton < Formula
   desc "📦 Watcher, bundler, and test runner for your SwiftWasm apps"
   homepage "https://carton.dev"
   head "https://github.com/swiftwasm/carton.git"
-
-  depends_on :xcode => "11.4"
-  depends_on "wasmer"
-  depends_on "binaryen"
 
   stable do
     version "0.9.1"
@@ -13,19 +12,24 @@ class Carton < Formula
     sha256 "bdf9e259e9abb9d2ff9b68380b08a29c7c4f6a4b1114473593c3fc8afe33e574"
   end
 
+  bottle do
+    root_url "https://github.com/swiftwasm/carton/releases/download/0.9.1"
+    sha256 cellar: :any, big_sur: "dd40aefac826c9739c81b69153326f023b8727839d41965ff63cf890734bca73"
+  end
+
+  depends_on "binaryen"
+
+  depends_on "wasmer"
+
+  depends_on xcode: "11.4"
+
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release"
     system "mv", ".build/release/carton", "carton"
     bin.install "carton"
   end
 
-  bottle do
-    root_url "https://github.com/swiftwasm/carton/releases/download/0.9.1"
-    cellar :any
-    sha256 "dd40aefac826c9739c81b69153326f023b8727839d41965ff63cf890734bca73" => :big_sur
-  end
-
   test do
-    system "carton -h"
+    system "carton", "-h"
   end
 end


### PR DESCRIPTION
My current version of Homebrew was giving me log messages around this formula, specifically:

```
Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the swiftwasm/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/swiftwasm/homebrew-tap/carton.rb:24

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the swiftwasm/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/swiftwasm/homebrew-tap/carton.rb:25
```

As suggested, I applied `brew style --fix` to `carton.rb` in this PR, which corrected the problem at hand (among 16 other things).  This command did make 2x additional suggestions that I chose not to apply here:

```
carton.rb:4:1: C: Missing top-level class documentation comment.
class Carton < Formula
^^^^^

carton.rb:28:12: C: Use the mv Ruby method instead of system "mv", ".build/release/carton", "carton"
    system "mv", ".build/release/carton", "carton"
           ^^^^
```